### PR TITLE
use setBufferSize to override MQTT_MAX_PACKET_SIZE

### DIFF
--- a/Alarm.ino
+++ b/Alarm.ino
@@ -91,7 +91,8 @@ void setup() {
     Serial.print("  DHCP assigned IP ");
     Serial.println(Ethernet.localIP());
   }
-
+  
+  client.setBufferSize(1024);
   client.setServer(mqtt_server, mqtt_port);
   client.setCallback(callback);
 


### PR DESCRIPTION
use setBufferSize to override MQTT_MAX_PACKET_SIZE so the end user doesn't need to modify an external file from another library.